### PR TITLE
Multi-NUMA support

### DIFF
--- a/pkg/kubelet/cm/memorymanager/BUILD
+++ b/pkg/kubelet/cm/memorymanager/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -43,4 +43,23 @@ filegroup(
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "memory_manager_test.go",
+        "policy_single_numa_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/kubelet/cm/memorymanager/state:go_default_library",
+        "//pkg/kubelet/cm/topologymanager:go_default_library",
+        "//pkg/kubelet/cm/topologymanager/bitmask:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
+    ],
 )

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -132,7 +132,11 @@ func NewManager(policyName string, machineInfo *cadvisorapi.MachineInfo, nodeAll
 		if err != nil {
 			return nil, err
 		}
-		policy = NewPolicySingleNUMA(machineInfo, systemReserved, affinity)
+
+		policy, err = NewPolicySingleNUMA(machineInfo, systemReserved, affinity)
+		if err != nil {
+			return nil, err
+		}
 
 	default:
 		return nil, fmt.Errorf("unknown policy: \"%s\"", policyName)

--- a/pkg/kubelet/cm/memorymanager/memory_manager.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager.go
@@ -181,7 +181,9 @@ func (m *manager) AddContainer(pod *v1.Pod, container *v1.Container, containerID
 	// Get NUMA node affinity of blocks assigned to the container during Allocate()
 	var nodes []string
 	for _, block := range m.state.GetMemoryBlocks(string(pod.UID), container.Name) {
-		nodes = append(nodes, strconv.Itoa(block.NUMAAffinity))
+		for _, nodeID := range block.NUMAAffinity {
+			nodes = append(nodes, strconv.Itoa(nodeID))
+		}
 	}
 
 	if len(nodes) < 1 {

--- a/pkg/kubelet/cm/memorymanager/memory_manager_test.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager_test.go
@@ -54,22 +54,6 @@ func getPod(podUID string, containerName string, requirements *v1.ResourceRequir
 
 type nodeResources map[v1.ResourceName]resource.Quantity
 
-func getPod(podUID string, containerName string, requirements *v1.ResourceRequirements) *v1.Pod {
-	return &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			UID: types.UID(podUID),
-		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
-				{
-					Name:      containerName,
-					Resources: *requirements,
-				},
-			},
-		},
-	}
-}
-
 // validatePreReservedMemory
 func TestValidatePreReservedMemory(t *testing.T) {
 	const msgNotEqual = "the total amount of memory of type \"%s\" is not equal to the value determined by Node Allocatable feature"

--- a/pkg/kubelet/cm/memorymanager/memory_manager_test.go
+++ b/pkg/kubelet/cm/memorymanager/memory_manager_test.go
@@ -36,6 +36,22 @@ const (
 	hugepages1G = "hugepages-1Gi"
 )
 
+func getPod(podUID string, containerName string, requirements *v1.ResourceRequirements) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: types.UID(podUID),
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:      containerName,
+					Resources: *requirements,
+				},
+			},
+		},
+	}
+}
+
 type nodeResources map[v1.ResourceName]resource.Quantity
 
 func getPod(podUID string, containerName string, requirements *v1.ResourceRequirements) *v1.Pod {

--- a/pkg/kubelet/cm/memorymanager/policy_single_numa.go
+++ b/pkg/kubelet/cm/memorymanager/policy_single_numa.go
@@ -39,13 +39,6 @@ type systemReservedMemory map[int]map[v1.ResourceName]uint64
 
 // SingleNUMAPolicy is implementation of the policy interface for the single NUMA policy
 type singleNUMAPolicy struct {
-	// TODO: define new kubelet flag and pass it to the ContainerManager -> MemoryManager -> singleNUMAPolicy
-	// multipleNUMAGroups defines groups of NUMA nodes that will be set to preferred under the topology hint generation
-	// for example on the machine with four NUMA nodes and with this parameter equals to [[0,2]], only hints
-	// [0010, 1000, 0101] will be preferred
-	// if this parameter is empty, the default behavior will be used to set preferred hints, it means that only hint
-	// with a minimal amount of nodes that should satisfy the request will be set to preferred
-	multipleNUMAGroups [][]int
 	// machineInfo contains machine memory related information
 	machineInfo *cadvisorapi.MachineInfo
 	// reserved contains memory that reserved for kube
@@ -326,6 +319,9 @@ func (p *singleNUMAPolicy) calculateHints(s state.State, requestedResources map[
 	}
 	sort.Ints(numaNodes)
 
+	// Initialize minAffinitySize to include all NUMA Nodes.
+	minAffinitySize := len(numaNodes)
+
 	hints := map[string][]topologymanager.TopologyHint{}
 	bitmask.IterateBitMasks(numaNodes, func(mask bitmask.BitMask) {
 		maskBits := mask.GetBits()
@@ -337,11 +333,12 @@ func (p *singleNUMAPolicy) calculateHints(s state.State, requestedResources map[
 		}
 
 		totalFreeSize := map[v1.ResourceName]uint64{}
+		totalAllocatableSize := map[v1.ResourceName]uint64{}
 		// calculate total free memory for the node mask
 		for _, nodeId := range maskBits {
 			// the node already used for the memory allocation
 			if !singleNUMAHint && machineState[nodeId].NumberOfAssignments > 0 {
-				// the node used for the single NUMA memory allocation, it can be used for the multiple NUMA node allocation
+				// the node used for the single NUMA memory allocation, it can be used for the multi NUMA node allocation
 				if len(machineState[nodeId].Nodes) == 1 {
 					return
 				}
@@ -357,17 +354,33 @@ func (p *singleNUMAPolicy) calculateHints(s state.State, requestedResources map[
 					totalFreeSize[resourceName] = 0
 				}
 				totalFreeSize[resourceName] += machineState[nodeId].MemoryMap[resourceName].Free
+
+				if _, ok := totalAllocatableSize[resourceName]; !ok {
+					totalAllocatableSize[resourceName] = 0
+				}
+				totalAllocatableSize[resourceName] += machineState[nodeId].MemoryMap[resourceName].Allocatable
 			}
 		}
 
-		// verify that for all memory types the node mask has enough resources
+		// verify that for all memory types the node mask has enough allocatable resources
+		for resourceName, requestedSize := range requestedResources {
+			if totalAllocatableSize[resourceName] < requestedSize {
+				return
+			}
+		}
+
+		// set the minimum amount of NUMA nodes that can satisfy the container resources requests
+		if mask.Count() < minAffinitySize {
+			minAffinitySize = mask.Count()
+		}
+
+		// verify that for all memory types the node mask has enough free resources
 		for resourceName, requestedSize := range requestedResources {
 			if totalFreeSize[resourceName] < requestedSize {
 				return
 			}
 		}
 
-		preferred := p.isHintPreferred(maskBits)
 		// add the node mask as topology hint for all memory types
 		for resourceName := range requestedResources {
 			if _, ok := hints[string(resourceName)]; !ok {
@@ -375,31 +388,24 @@ func (p *singleNUMAPolicy) calculateHints(s state.State, requestedResources map[
 			}
 			hints[string(resourceName)] = append(hints[string(resourceName)], topologymanager.TopologyHint{
 				NUMANodeAffinity: mask,
-				Preferred:        preferred,
+				Preferred:        false,
 			})
 		}
 	})
 
+	// update hints preferred according to multiNUMAGroups, in case when it wasn't provided, the default
+	// behaviour to prefer the minimal amount of NUMA nodes will be used
+	for resourceName := range requestedResources {
+		for i, hint := range hints[string(resourceName)] {
+			hints[string(resourceName)][i].Preferred = p.isHintPreferred(hint.NUMANodeAffinity.GetBits(), minAffinitySize)
+		}
+	}
+
 	return hints
 }
 
-func (p *singleNUMAPolicy) isHintPreferred(maskBits []int) bool {
-	// check if the mask is for the single NUMA node hint
-	if len(maskBits) == 1 {
-		// the node should be used only for multiple NUMA memory allocation
-		return !p.isMultipleNUMANode(maskBits[0])
-	}
-
-	return p.isMultipleNUMAGroup(maskBits)
-}
-
-func (p *singleNUMAPolicy) isMultipleNUMAGroup(maskBits []int) bool {
-	for _, group := range p.multipleNUMAGroups {
-		if areGroupsEqual(group, maskBits) {
-			return true
-		}
-	}
-	return false
+func (p *singleNUMAPolicy) isHintPreferred(maskBits []int, minAffinitySize int) bool {
+	return len(maskBits) == minAffinitySize
 }
 
 func areGroupsEqual(group1, group2 []int) bool {
@@ -416,17 +422,6 @@ func areGroupsEqual(group1, group2 []int) bool {
 		}
 	}
 	return true
-}
-
-func (p *singleNUMAPolicy) isMultipleNUMANode(nodeId int) bool {
-	for _, group := range p.multipleNUMAGroups {
-		for _, groupNode := range group {
-			if nodeId == groupNode {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func (p *singleNUMAPolicy) validateState(s state.State) error {

--- a/pkg/kubelet/cm/memorymanager/policy_single_numa.go
+++ b/pkg/kubelet/cm/memorymanager/policy_single_numa.go
@@ -39,6 +39,7 @@ type systemReservedMemory map[int]map[v1.ResourceName]uint64
 
 // SingleNUMAPolicy is implementation of the policy interface for the single NUMA policy
 type singleNUMAPolicy struct {
+	// TODO: define new kubelet flag and pass it to the ContainerManager -> MemoryManager -> singleNUMAPolicy
 	// crossNUMAGroups contains groups of NUMA node that can be used for cross NUMA memory allocations
 	crossNUMAGroups [][]int
 	// machineInfo contains machine memory related information
@@ -141,8 +142,23 @@ func (p *singleNUMAPolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Co
 	var containerBlocks []state.Block
 	maskBits := bestHint.NUMANodeAffinity.GetBits()
 	for resourceName, requestedSize := range requestedResources {
+		// update memory blocks
+		containerBlocks = append(containerBlocks, state.Block{
+			NUMAAffinity: maskBits,
+			Size:         requestedSize,
+			Type:         resourceName,
+		})
+
 		// Update nodes memory state
 		for _, nodeId := range maskBits {
+			machineState[nodeId].NumberOfAssignments++
+			machineState[nodeId].Nodes = maskBits
+
+			// we need to continue to update all affinity mask nodes
+			if requestedSize == 0 {
+				continue
+			}
+
 			// update the node memory state
 			nodeResourceMemoryState := machineState[nodeId].MemoryMap[resourceName]
 			if nodeResourceMemoryState.Free <= 0 {
@@ -153,7 +169,8 @@ func (p *singleNUMAPolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Co
 			if nodeResourceMemoryState.Free >= requestedSize {
 				nodeResourceMemoryState.Reserved += requestedSize
 				nodeResourceMemoryState.Free -= requestedSize
-				break
+				requestedSize = 0
+				continue
 			}
 
 			// the node does not have enough memory, use the node remaining memory and move to the next node
@@ -161,19 +178,6 @@ func (p *singleNUMAPolicy) Allocate(s state.State, pod *v1.Pod, container *v1.Co
 			nodeResourceMemoryState.Reserved += nodeResourceMemoryState.Free
 			nodeResourceMemoryState.Free = 0
 		}
-
-		// update memory blocks
-		containerBlocks = append(containerBlocks, state.Block{
-			NUMAAffinity: bestHint.NUMANodeAffinity.GetBits(),
-			Size:         requestedSize,
-			Type:         resourceName,
-		})
-	}
-
-	// Update each node number of assignments and group
-	for _, nodeId := range maskBits {
-		machineState[nodeId].NumberOfAssignments++
-		machineState[nodeId].Nodes = maskBits
 	}
 
 	s.SetMachineState(machineState)
@@ -195,12 +199,43 @@ func (p *singleNUMAPolicy) RemoveContainer(s state.State, podUID string, contain
 	// Mutate machine memory state to update free and reserved memory
 	machineState := s.GetMachineState()
 	for _, b := range blocks {
+		releasedSize := b.Size
 		for _, nodeId := range b.NUMAAffinity {
+			machineState[nodeId].NumberOfAssignments--
+
+			// once we do not have any memory allocations on this node, clear node groups
+			if machineState[nodeId].NumberOfAssignments == 0 {
+				machineState[nodeId].Nodes = []int{nodeId}
+			}
+
+			// we still need to pass over all NUMA node under the affinity mask to update them
+			if releasedSize == 0 {
+				continue
+			}
+
 			nodeResourceMemoryState := machineState[nodeId].MemoryMap[b.Type]
-			nodeResourceMemoryState.Free += b.Size
-			nodeResourceMemoryState.Reserved -= b.Size
+
+			// if the node does not have reserved memory to free, continue to the next node
+			if nodeResourceMemoryState.Reserved == 0 {
+				continue
+			}
+
+			// the reserved memory smaller than the amount of the memory that should be released
+			// release as much as possible and move to the next node
+			if nodeResourceMemoryState.Reserved < releasedSize {
+				nodeResourceMemoryState.Free += nodeResourceMemoryState.Reserved
+				nodeResourceMemoryState.Reserved = 0
+				releasedSize -= nodeResourceMemoryState.Reserved
+				continue
+			}
+
+			// the reserved memory big enough to satisfy the released memory
+			nodeResourceMemoryState.Free += releasedSize
+			nodeResourceMemoryState.Reserved -= releasedSize
+			releasedSize = 0
 		}
 	}
+
 	s.SetMachineState(machineState)
 
 	return nil
@@ -231,7 +266,7 @@ func (p *singleNUMAPolicy) GetTopologyHints(s state.State, pod *v1.Pod, containe
 	// kubelet restart, for example.
 	if containerBlocks != nil {
 		if len(containerBlocks) != len(requestedResources) {
-			klog.Errorf("[memorymanager] The number of requested resources of the container %s differs from the number of memory blocks", container.Name)
+			klog.Errorf("[memorymanager] The number of requested resources by the container %s differs from the number of memory blocks", container.Name)
 			return nil
 		}
 
@@ -280,17 +315,14 @@ func getRequestedResources(container *v1.Container) (map[v1.ResourceName]uint64,
 }
 
 func (p *singleNUMAPolicy) calculateHints(s state.State, requestedResources map[v1.ResourceName]uint64) map[string][]topologymanager.TopologyHint {
-	hints := map[string][]topologymanager.TopologyHint{}
-	for resourceName := range requestedResources {
-		hints[string(resourceName)] = []topologymanager.TopologyHint{}
-	}
-
 	machineState := s.GetMachineState()
 	var numaNodes []int
 	for n := range machineState {
 		numaNodes = append(numaNodes, n)
 	}
+	sort.Ints(numaNodes)
 
+	hints := map[string][]topologymanager.TopologyHint{}
 	bitmask.IterateBitMasks(numaNodes, func(mask bitmask.BitMask) {
 		maskBits := mask.GetBits()
 		singleNUMAHint := len(maskBits) == 1
@@ -304,7 +336,7 @@ func (p *singleNUMAPolicy) calculateHints(s state.State, requestedResources map[
 		// calculate total free memory for the node mask
 		for _, nodeId := range maskBits {
 			// the node already used for the memory allocation
-			if !singleNUMAHint && machineState[nodeId].NumberOfAssignments != 0 {
+			if !singleNUMAHint && machineState[nodeId].NumberOfAssignments > 0 {
 				// the node used for the single NUMA memory allocation, it can be used for the cross NUMA node allocation
 				if len(machineState[nodeId].Nodes) == 1 {
 					return
@@ -334,6 +366,9 @@ func (p *singleNUMAPolicy) calculateHints(s state.State, requestedResources map[
 		preferred := p.isHintPreferred(maskBits)
 		// add the node mask as topology hint for all memory types
 		for resourceName := range requestedResources {
+			if _, ok := hints[string(resourceName)]; !ok {
+				hints[string(resourceName)] = []topologymanager.TopologyHint{}
+			}
 			hints[string(resourceName)] = append(hints[string(resourceName)], topologymanager.TopologyHint{
 				NUMANodeAffinity: mask,
 				Preferred:        preferred,
@@ -418,15 +453,16 @@ func (p *singleNUMAPolicy) validateState(s state.State) error {
 						return fmt.Errorf("[memorymanager] (pod: %s, container: %s) the memory assignment uses the NUMA that does not exist", pod, containerName)
 					}
 
-					if nodeState.NumberOfAssignments != 0 && !areGroupsEqual(nodeState.Nodes, b.NUMAAffinity) {
-						return fmt.Errorf("[memorymanager] node state group %v and container NUMA affinity %v are different", nodeState.Nodes, b.NUMAAffinity)
-					}
 					nodeState.NumberOfAssignments++
 					nodeState.Nodes = b.NUMAAffinity
 
 					memoryState, ok := nodeState.MemoryMap[b.Type]
 					if !ok {
 						return fmt.Errorf("[memorymanager] (pod: %s, container: %s) the memory assignment uses memory resource that does not exist", pod, containerName)
+					}
+
+					if requestedSize == 0 {
+						continue
 					}
 
 					// this node does not have enough memory continue to the next one
@@ -438,7 +474,8 @@ func (p *singleNUMAPolicy) validateState(s state.State) error {
 					if memoryState.Free >= requestedSize {
 						memoryState.Reserved += requestedSize
 						memoryState.Free -= requestedSize
-						break
+						requestedSize = 0
+						continue
 					}
 
 					// the node does not have enough memory, use the node remaining memory and move to the next node
@@ -497,7 +534,7 @@ func areMachineStatesEqual(ms1, ms2 state.NodeMap) bool {
 			}
 
 			if !reflect.DeepEqual(*memoryState1, *memoryState2) {
-				klog.Errorf("[memorymanager] memory states for the resource %s are different: %+v != %+v", resourceName, *memoryState1, *memoryState1)
+				klog.Errorf("[memorymanager] memory states for the NUMA node %d and the resource %s are different: %+v != %+v", nodeId, resourceName, *memoryState1, *memoryState2)
 				return false
 			}
 		}
@@ -552,29 +589,6 @@ func (p *singleNUMAPolicy) getResourceSystemReserved(nodeId int, resourceName v1
 		}
 	}
 	return systemReserved
-}
-
-func (p *singleNUMAPolicy) validateResourceMemory(node *cadvisorapi.Node, expectedTotal uint64, machineMemory map[v1.ResourceName]*state.MemoryTable, resourceName v1.ResourceName) error {
-	resourceSize, ok := machineMemory[resourceName]
-	if !ok {
-		return fmt.Errorf("[memorymanager] machine state does not have %s resource", resourceName)
-	}
-
-	if expectedTotal != resourceSize.TotalMemSize {
-		return fmt.Errorf("[memorymanager] machine state has different size of the total %s", resourceName)
-	}
-
-	if p.systemReserved[node.Id][resourceName] != resourceSize.SystemReserved {
-		return fmt.Errorf("[memorymanager] machine state has different size of the system reserved %s", resourceName)
-	}
-	return nil
-}
-
-func (p *singleNUMAPolicy) validateResourceReservedMemory(assignmentsMemory map[v1.ResourceName]uint64, machineMemory map[v1.ResourceName]*state.MemoryTable, resourceName v1.ResourceName) error {
-	if assignmentsMemory[resourceName] != machineMemory[resourceName].Reserved {
-		return fmt.Errorf("[memorymanager] %s reserved by containers differs from the machine state reserved", resourceName)
-	}
-	return nil
 }
 
 func (p *singleNUMAPolicy) getDefaultHint(s state.State, requestedResources map[v1.ResourceName]uint64) (*topologymanager.TopologyHint, error) {
@@ -636,12 +650,16 @@ func isHintInGroup(hint []int, group []int) bool {
 
 	hintIndex := 0
 	for i := range group {
+		if hintIndex == len(hint) {
+			return true
+		}
+
 		if group[i] != hint[hintIndex] {
 			continue
 		}
 		hintIndex++
 	}
-	return hintIndex == len(hint)-1
+	return false
 }
 
 func findBestHint(hints []topologymanager.TopologyHint) *topologymanager.TopologyHint {

--- a/pkg/kubelet/cm/memorymanager/policy_single_numa_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_single_numa_test.go
@@ -141,7 +141,7 @@ func TestSingleNUMAPolicyStart(t *testing.T) {
 				"pod": map[string][]state.Block{
 					"container1": {
 						{
-							NUMAAffinity: 0,
+							NUMAAffinity: []int{0},
 							Type:         v1.ResourceMemory,
 							Size:         512 * mb,
 						},
@@ -366,7 +366,7 @@ func TestSingleNUMAPolicyStart(t *testing.T) {
 				"pod": map[string][]state.Block{
 					"container1": {
 						{
-							NUMAAffinity: 0,
+							NUMAAffinity: []int{0},
 							Type:         v1.ResourceMemory,
 							Size:         512 * mb,
 						},
@@ -505,7 +505,7 @@ func TestSingleNUMAPolicyStart(t *testing.T) {
 				"pod1": map[string][]state.Block{
 					"container1": {
 						{
-							NUMAAffinity: 0,
+							NUMAAffinity: []int{0},
 							Type:         hugepages1Gi,
 							Size:         gb,
 						},
@@ -514,7 +514,7 @@ func TestSingleNUMAPolicyStart(t *testing.T) {
 				"pod2": map[string][]state.Block{
 					"container2": {
 						{
-							NUMAAffinity: 0,
+							NUMAAffinity: []int{0},
 							Type:         hugepages1Gi,
 							Size:         gb,
 						},
@@ -653,7 +653,7 @@ func TestSingleNUMAPolicyAllocate(t *testing.T) {
 				"pod1": map[string][]state.Block{
 					"container1": {
 						{
-							NUMAAffinity: 0,
+							NUMAAffinity: []int{0},
 							Type:         v1.ResourceMemory,
 							Size:         gb,
 						},
@@ -664,7 +664,7 @@ func TestSingleNUMAPolicyAllocate(t *testing.T) {
 				"pod1": map[string][]state.Block{
 					"container1": {
 						{
-							NUMAAffinity: 0,
+							NUMAAffinity: []int{0},
 							Type:         v1.ResourceMemory,
 							Size:         gb,
 						},
@@ -728,12 +728,12 @@ func TestSingleNUMAPolicyAllocate(t *testing.T) {
 				"pod1": map[string][]state.Block{
 					"container1": {
 						{
-							NUMAAffinity: 0,
+							NUMAAffinity: []int{0},
 							Type:         v1.ResourceMemory,
 							Size:         gb,
 						},
 						{
-							NUMAAffinity: 0,
+							NUMAAffinity: []int{0},
 							Type:         hugepages1Gi,
 							Size:         gb,
 						},
@@ -876,12 +876,12 @@ func TestSingleNUMAPolicyRemoveContainer(t *testing.T) {
 				"pod1": map[string][]state.Block{
 					"container1": {
 						{
-							NUMAAffinity: 0,
+							NUMAAffinity: []int{0},
 							Type:         v1.ResourceMemory,
 							Size:         gb,
 						},
 						{
-							NUMAAffinity: 0,
+							NUMAAffinity: []int{0},
 							Type:         hugepages1Gi,
 							Size:         gb,
 						},
@@ -988,12 +988,12 @@ func TestSingleNUMAPolicyGetTopologyHints(t *testing.T) {
 				"pod1": map[string][]state.Block{
 					"container1": {
 						{
-							NUMAAffinity: 0,
+							NUMAAffinity: []int{0},
 							Type:         v1.ResourceMemory,
 							Size:         gb,
 						},
 						{
-							NUMAAffinity: 0,
+							NUMAAffinity: []int{0},
 							Type:         hugepages1Gi,
 							Size:         gb,
 						},
@@ -1022,12 +1022,12 @@ func TestSingleNUMAPolicyGetTopologyHints(t *testing.T) {
 				"pod1": map[string][]state.Block{
 					"container1": {
 						{
-							NUMAAffinity: 0,
+							NUMAAffinity: []int{0},
 							Type:         v1.ResourceMemory,
 							Size:         gb,
 						},
 						{
-							NUMAAffinity: 0,
+							NUMAAffinity: []int{0},
 							Type:         hugepages1Gi,
 							Size:         gb,
 						},

--- a/pkg/kubelet/cm/memorymanager/policy_single_numa_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_single_numa_test.go
@@ -801,7 +801,7 @@ func TestSingleNUMAPolicyAllocate(t *testing.T) {
 						},
 					},
 					Nodes:               []int{0},
-					NumberOfAssignments: 1,
+					NumberOfAssignments: 2,
 				},
 			},
 			systemReserved: systemReservedMemory{
@@ -932,7 +932,8 @@ func TestSingleNUMAPolicyRemoveContainer(t *testing.T) {
 							TotalMemSize:   gb,
 						},
 					},
-					Nodes: []int{},
+					NumberOfAssignments: 2,
+					Nodes:               []int{0},
 				},
 			},
 			expectedMachineState: state.NodeMap{
@@ -953,7 +954,8 @@ func TestSingleNUMAPolicyRemoveContainer(t *testing.T) {
 							TotalMemSize:   gb,
 						},
 					},
-					Nodes: []int{},
+					Nodes:               []int{0},
+					NumberOfAssignments: 0,
 				},
 			},
 			systemReserved: systemReservedMemory{

--- a/pkg/kubelet/cm/memorymanager/policy_single_numa_test.go
+++ b/pkg/kubelet/cm/memorymanager/policy_single_numa_test.go
@@ -976,6 +976,11 @@ func TestSingleNUMAPolicyGetTopologyHints(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
+	affinity2, err := bitmask.NewBitMask(0, 1)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
 	testCases := []testSingleNUMAPolicy{
 		{
 			description:           "should not provide topology hints for non-guaranteed pods",
@@ -1081,11 +1086,19 @@ func TestSingleNUMAPolicyGetTopologyHints(t *testing.T) {
 						NUMANodeAffinity: affinity1,
 						Preferred:        true,
 					},
+					{
+						NUMANodeAffinity: affinity2,
+						Preferred:        false,
+					},
 				},
 				string(hugepages1Gi): {
 					{
 						NUMANodeAffinity: affinity1,
 						Preferred:        true,
+					},
+					{
+						NUMANodeAffinity: affinity2,
+						Preferred:        false,
 					},
 				},
 			},

--- a/pkg/kubelet/cm/memorymanager/state/checkpoint.go
+++ b/pkg/kubelet/cm/memorymanager/state/checkpoint.go
@@ -28,7 +28,7 @@ var _ checkpointmanager.Checkpoint = &MemoryManagerCheckpoint{}
 // MemoryManagerCheckpoint struct is used to store memory/pod assignments in a checkpoint
 type MemoryManagerCheckpoint struct {
 	PolicyName   string                     `json:"policyName"`
-	MachineState MemoryMap                  `json:"machineState"`
+	MachineState NodeMap                    `json:"machineState"`
 	Entries      ContainerMemoryAssignments `json:"entries,omitempty"`
 	Checksum     checksum.Checksum          `json:"checksum"`
 }
@@ -38,7 +38,7 @@ func NewMemoryManagerCheckpoint() *MemoryManagerCheckpoint {
 	//lint:ignore unexported-type-in-api user-facing error message
 	return &MemoryManagerCheckpoint{
 		Entries:      ContainerMemoryAssignments{},
-		MachineState: MemoryMap{},
+		MachineState: NodeMap{},
 	}
 }
 

--- a/pkg/kubelet/cm/memorymanager/state/state.go
+++ b/pkg/kubelet/cm/memorymanager/state/state.go
@@ -31,7 +31,8 @@ type MemoryTable struct {
 
 // NodeState contains NUMA node related information
 type NodeState struct {
-	// NumberOfAssignments contains a number of containers that allocated the memory from this NUMA node
+	// NumberOfAssignments contains a number memory assignments from this node
+	// When the container requires memory and hugepages it will increase number of assignments by two
 	NumberOfAssignments int `json:"numberOfAssignments"`
 	// MemoryTable contains NUMA node memory related information
 	MemoryMap map[v1.ResourceName]*MemoryTable `json:"memoryMap"`

--- a/pkg/kubelet/cm/memorymanager/state/state.go
+++ b/pkg/kubelet/cm/memorymanager/state/state.go
@@ -36,8 +36,8 @@ type NodeState struct {
 	NumberOfAssignments int `json:"numberOfAssignments"`
 	// MemoryTable contains NUMA node memory related information
 	MemoryMap map[v1.ResourceName]*MemoryTable `json:"memoryMap"`
-	// Nodes contains the current NUMA node and all other nodes that current NUMA node in group with them
-	// This parameter used to indicate if the current node used for the multiple NUMA node memory allocation
+	// Nodes contains the current NUMA node and all other nodes that are in a group with current NUMA node
+	// This parameter indicates if the current node is used for the multiple NUMA node memory allocation
 	// For example if some container has pinning 0,1,2, NUMA nodes 0,1,2 under the state will have
 	// this parameter equals to [0, 1, 2]
 	Nodes []int `json:"nodes"`

--- a/pkg/kubelet/cm/memorymanager/state/state.go
+++ b/pkg/kubelet/cm/memorymanager/state/state.go
@@ -76,7 +76,8 @@ func (nm NodeMap) Clone() NodeMap {
 
 // Block is a data structure used to represent a certain amount of memory
 type Block struct {
-	NUMAAffinity int             `json:"numaAffinity"`
+	// NUMAAffinity contains the string that represents NUMA affinity bitmask
+	NUMAAffinity []int           `json:"numaAffinity"`
 	Type         v1.ResourceName `json:"type"`
 	Size         uint64          `json:"size"`
 }

--- a/pkg/kubelet/cm/memorymanager/state/state.go
+++ b/pkg/kubelet/cm/memorymanager/state/state.go
@@ -36,8 +36,10 @@ type NodeState struct {
 	NumberOfAssignments int `json:"numberOfAssignments"`
 	// MemoryTable contains NUMA node memory related information
 	MemoryMap map[v1.ResourceName]*MemoryTable `json:"memoryMap"`
-	// NodeGroups contains NUMA nodes that current NUMA node in group with them
-	// It means that we have container that pinned to the current NUMA node and all group nodes
+	// Nodes contains the current NUMA node and all other nodes that current NUMA node in group with them
+	// This parameter used to indicate if the current node used for the multiple NUMA node memory allocation
+	// For example if some container has pinning 0,1,2, NUMA nodes 0,1,2 under the state will have
+	// this parameter equals to [0, 1, 2]
 	Nodes []int `json:"nodes"`
 }
 

--- a/pkg/kubelet/cm/memorymanager/state/state_checkpoint.go
+++ b/pkg/kubelet/cm/memorymanager/state/state_checkpoint.go
@@ -75,6 +75,10 @@ func (sc *stateCheckpoint) restoreState() error {
 		return err
 	}
 
+	if sc.policyName != checkpoint.PolicyName {
+		return fmt.Errorf("[memorymanager] configured policy %q differs from state checkpoint policy %q", sc.policyName, checkpoint.PolicyName)
+	}
+
 	sc.cache.SetMachineState(checkpoint.MachineState)
 	sc.cache.SetMemoryAssignments(checkpoint.Entries)
 
@@ -99,7 +103,7 @@ func (sc *stateCheckpoint) storeState() error {
 }
 
 // GetMemoryState returns Memory Map stored in the State
-func (sc *stateCheckpoint) GetMachineState() MemoryMap {
+func (sc *stateCheckpoint) GetMachineState() NodeMap {
 	sc.RLock()
 	defer sc.RUnlock()
 
@@ -122,8 +126,8 @@ func (sc *stateCheckpoint) GetMemoryAssignments() ContainerMemoryAssignments {
 	return sc.cache.GetMemoryAssignments()
 }
 
-// SetMachineState stores MemoryMap in State
-func (sc *stateCheckpoint) SetMachineState(memoryMap MemoryMap) {
+// SetMachineState stores NodeMap in State
+func (sc *stateCheckpoint) SetMachineState(memoryMap NodeMap) {
 	sc.Lock()
 	defer sc.Unlock()
 

--- a/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
+++ b/pkg/kubelet/cm/memorymanager/state/state_checkpoint_test.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/klog"
-
 	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
@@ -66,8 +64,8 @@ func TestCheckpointStateRestore(t *testing.T) {
 			`{
 				"policyName":"singleNUMA",
 				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"nodes":[]}},
-				"entries":{"pod":{"container1":[{"numaAffinity":0,"type":"memory","size":512}]}},
-				"checksum": 2903074075
+				"entries":{"pod":{"container1":[{"numaAffinity":[0],"type":"memory","size":512}]}},
+				"checksum": 2568607641
 			}`,
 			containermap.ContainerMap{},
 			"",
@@ -76,7 +74,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 					"pod": map[string][]Block{
 						"container1": {
 							{
-								NUMAAffinity: 0,
+								NUMAAffinity: []int{0},
 								Type:         v1.ResourceMemory,
 								Size:         512,
 							},
@@ -103,7 +101,7 @@ func TestCheckpointStateRestore(t *testing.T) {
 			`{
 				"policyName":"singleNUMA",
 				"machineState":{"0":{"numberOfAssignments":0,"memoryMap":{"memory":{"total":2048,"systemReserved":512,"allocatable":1536,"reserved":512,"free":1024}},"nodes":[]}},
-				"entries":{"pod":{"container1":[{"affinity":0,"type":"memory","size":512}]}},
+				"entries":{"pod":{"container1":[{"affinity":[0],"type":"memory","size":512}]}},
 				"checksum": 101010
 			}`,
 			containermap.ContainerMap{},
@@ -135,9 +133,6 @@ func TestCheckpointStateRestore(t *testing.T) {
 			}
 
 			restoredState, err := NewCheckpointState(testingDir, testingCheckpoint, "singleNUMA", tc.initialContainers)
-			if err != nil {
-				klog.Infof("MYERROR: %v", err)
-			}
 			if strings.TrimSpace(tc.expectedError) != "" {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), "could not restore state from checkpoint: "+tc.expectedError)
@@ -156,7 +151,7 @@ func TestCheckpointStateStore(t *testing.T) {
 			"pod": map[string][]Block{
 				"container1": {
 					{
-						NUMAAffinity: 0,
+						NUMAAffinity: []int{0},
 						Type:         v1.ResourceMemory,
 						Size:         1024,
 					},
@@ -209,7 +204,7 @@ func TestCheckpointStateHelpers(t *testing.T) {
 				"pod": map[string][]Block{
 					"container1": {
 						{
-							NUMAAffinity: 0,
+							NUMAAffinity: []int{0},
 							Type:         v1.ResourceMemory,
 							Size:         1024,
 						},
@@ -237,14 +232,14 @@ func TestCheckpointStateHelpers(t *testing.T) {
 				"pod": map[string][]Block{
 					"container1": {
 						{
-							NUMAAffinity: 0,
+							NUMAAffinity: []int{0},
 							Type:         v1.ResourceMemory,
 							Size:         512,
 						},
 					},
 					"container2": {
 						{
-							NUMAAffinity: 0,
+							NUMAAffinity: []int{0},
 							Type:         v1.ResourceMemory,
 							Size:         512,
 						},
@@ -329,7 +324,7 @@ func TestCheckpointStateClear(t *testing.T) {
 				"pod": map[string][]Block{
 					"container1": {
 						{
-							NUMAAffinity: 0,
+							NUMAAffinity: []int{0},
 							Type:         v1.ResourceMemory,
 							Size:         1024,
 						},

--- a/pkg/kubelet/cm/memorymanager/state/state_mem.go
+++ b/pkg/kubelet/cm/memorymanager/state/state_mem.go
@@ -25,7 +25,7 @@ import (
 type stateMemory struct {
 	sync.RWMutex
 	assignments  ContainerMemoryAssignments
-	machineState MemoryMap
+	machineState NodeMap
 }
 
 var _ State = &stateMemory{}
@@ -35,12 +35,12 @@ func NewMemoryState() State {
 	klog.Infof("[memorymanager] initializing new in-memory state store")
 	return &stateMemory{
 		assignments:  ContainerMemoryAssignments{},
-		machineState: MemoryMap{},
+		machineState: NodeMap{},
 	}
 }
 
 // GetMemoryState returns Memory Map stored in the State
-func (s *stateMemory) GetMachineState() MemoryMap {
+func (s *stateMemory) GetMachineState() NodeMap {
 	s.RLock()
 	defer s.RUnlock()
 
@@ -66,12 +66,12 @@ func (s *stateMemory) GetMemoryAssignments() ContainerMemoryAssignments {
 	return s.assignments.Clone()
 }
 
-// SetMachineState stores MemoryMap in State
-func (s *stateMemory) SetMachineState(memoryMap MemoryMap) {
+// SetMachineState stores NodeMap in State
+func (s *stateMemory) SetMachineState(nodeMap NodeMap) {
 	s.Lock()
 	defer s.Unlock()
 
-	s.machineState = memoryMap
+	s.machineState = nodeMap
 	klog.Info("[memorymanager] updated machine memory state")
 }
 
@@ -121,7 +121,7 @@ func (s *stateMemory) ClearState() {
 	s.Lock()
 	defer s.Unlock()
 
-	s.machineState = MemoryMap{}
+	s.machineState = NodeMap{}
 	s.assignments = make(ContainerMemoryAssignments)
 	klog.V(2).Infof("[memorymanager] cleared state")
 }


### PR DESCRIPTION
## Struct Changes

To have possibility to monitor NUMA nodes that involved into
the multi-NUMA alignment of the memory, I introduce additional
fields under the machine state type.

We need number of assignments, to know if we already allocated memory
for the container from this NUMA node, after it the code will check if
the node has some nodes under the `Nodes`, if it does not have any nodes,
it means that the current node used for the single NUMA node allocation,
otherwise it used for the multi-NUMA allocation.

## Method Changes
Now the `GetTopologyHints` method will return also multi-NUMA
hints, with some restrictions:

- preferred hints will be only single NUMA hints, with nodes that
not included under the multi-NUMA node `kubelet` flag and multi-NUMA
hints with nodes included under the flag
- if the node already has single NUMA node assignment, it can not be used for
multi-NUMA assignment and vice versa
- node can not be used for multi-NUMA assignment, if it already has assignment,
within different group

## Memory calculation

In cases when the multi-NUMA requested, the code will firstly check the first node, if it has enough memory, we will use the memory from it and update only one node information, otherwise it will allocate as much as possible updated the state of the node, and will move to the next node.

## TODO
- [x] adapt `Allocate` method
- [x] adapt `RemoveContainer` method